### PR TITLE
Improvement/prevent replace exetranl link

### DIFF
--- a/src/services/ReplaceLinkService.php
+++ b/src/services/ReplaceLinkService.php
@@ -27,8 +27,8 @@ class ReplaceLinkService extends Component
      */
     public function replaceUrl(string $url, LanguageEntry $language, bool $evenExcluded = true): string
     {
-        $currentHost = parse_url($this->requestUrlService->getFullUrl(), PHP_URL_HOST);
-        $urlHost = parse_url($url, PHP_URL_HOST);
+        $currentHost = parse_url($this->requestUrlService->getFullUrl(), \PHP_URL_HOST);
+        $urlHost = parse_url($url, \PHP_URL_HOST);
 
         if ($urlHost && $currentHost && $urlHost !== $currentHost) {
             return $url;

--- a/src/services/ReplaceLinkService.php
+++ b/src/services/ReplaceLinkService.php
@@ -27,6 +27,13 @@ class ReplaceLinkService extends Component
      */
     public function replaceUrl(string $url, LanguageEntry $language, bool $evenExcluded = true): string
     {
+        $currentHost = parse_url($this->requestUrlService->getFullUrl(), PHP_URL_HOST);
+        $urlHost = parse_url($url, PHP_URL_HOST);
+
+        if ($urlHost && $currentHost && $urlHost !== $currentHost) {
+            return $url;
+        }
+
         $weglotUrl = $this->requestUrlService->createUrlObject($url);
         $replacedUrl = $weglotUrl->getForLanguage($language, $evenExcluded);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change that only adds a host check to avoid mutating external URLs; minimal behavioral impact beyond skipping previously-applied replacements.
> 
> **Overview**
> `ReplaceLinkService::replaceUrl()` now detects when an input URL points to a different host than the current request and returns it unchanged, preventing Weglot language rewriting/slug translation from affecting external links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a62e68d31704faacb3ef6b2001f9ec2163afdb88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->