### PR TITLE
Improvement/separate dynamics option and algolia option

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,6 +19,7 @@ return (new PhpCsFixer\Config())
         '@Symfony:risky' => true,
 
         // Override Symfony config
+        'declare_strict_types' => true,
         'method_argument_space' => [
             'after_heredoc' => true,
             'on_multiline' => 'ensure_fully_multiline',

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 
 return (new Configuration())

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 
 return (new Configuration())

--- a/composer.lock
+++ b/composer.lock
@@ -62,23 +62,22 @@
         },
         {
             "name": "brick/math",
-            "version": "0.14.8",
+            "version": "0.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629"
+                "reference": "6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/63422359a44b7f06cae63c3b429b59e8efcc0629",
-                "reference": "63422359a44b7f06cae63c3b429b59e8efcc0629",
+                "url": "https://api.github.com/repos/brick/math/zipball/6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b",
+                "reference": "6aef71a9fbbd1ee7be0e313cd627f8e6f7125a5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.2"
             },
             "require-dev": {
-                "php-coveralls/php-coveralls": "^2.2",
                 "phpstan/phpstan": "2.1.22",
                 "phpunit/phpunit": "^11.5"
             },
@@ -110,7 +109,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.8"
+                "source": "https://github.com/brick/math/tree/0.17.1"
             },
             "funding": [
                 {
@@ -118,7 +117,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-10T14:33:43+00:00"
+            "time": "2026-04-19T20:55:20+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -475,16 +474,16 @@
         },
         {
             "name": "craftcms/cms",
-            "version": "5.9.18",
+            "version": "5.9.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/craftcms/cms.git",
-                "reference": "c14474f31e4b8e5464c92c8f0d84753c96fef288"
+                "reference": "315646752b96630d840231b4b0b2f76e8d2d5f64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craftcms/cms/zipball/c14474f31e4b8e5464c92c8f0d84753c96fef288",
-                "reference": "c14474f31e4b8e5464c92c8f0d84753c96fef288",
+                "url": "https://api.github.com/repos/craftcms/cms/zipball/315646752b96630d840231b4b0b2f76e8d2d5f64",
+                "reference": "315646752b96630d840231b4b0b2f76e8d2d5f64",
                 "shasum": ""
             },
             "require": {
@@ -492,7 +491,7 @@
                 "commerceguys/addressing": "^2.1.1",
                 "composer/semver": "^3.3.2",
                 "craftcms/plugin-installer": "~1.6.0",
-                "craftcms/server-check": "~5.0.1",
+                "craftcms/server-check": "~5.1.0",
                 "creocoder/yii2-nested-sets": "~0.9.0",
                 "elvanto/litemoji": "~4.3.0",
                 "enshrined/svg-sanitize": "~0.22.0",
@@ -516,6 +515,7 @@
                 "php": "^8.2",
                 "phpdocumentor/reflection-docblock": "^5.3",
                 "phpoffice/phpspreadsheet": "^5.3",
+                "pixelandtonic/graphql-php": "~14.11.10.1",
                 "pixelandtonic/imagine": "~1.3.3.1",
                 "pragmarx/google2fa": "^8.0",
                 "pragmarx/recovery": "^0.2.1",
@@ -534,7 +534,6 @@
                 "twig/twig": "~3.21.1",
                 "voku/portable-ascii": "^2.0",
                 "web-auth/webauthn-lib": "~5.2.4",
-                "webonyx/graphql-php": "~14.11.10",
                 "yiisoft/yii2": "~2.0.54.0",
                 "yiisoft/yii2-debug": "~2.1.27.0",
                 "yiisoft/yii2-queue": "~2.3.2",
@@ -600,8 +599,7 @@
                 "rss": "https://github.com/craftcms/cms/releases.atom",
                 "source": "https://github.com/craftcms/cms"
             },
-
-            "time": "2026-03-26T22:22:13+00:00"
+            "time": "2026-04-14T15:47:56+00:00"
         },
         {
             "name": "craftcms/plugin-installer",
@@ -658,16 +656,16 @@
         },
         {
             "name": "craftcms/server-check",
-            "version": "5.0.4",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/craftcms/server-check.git",
-                "reference": "3b1f239c1cc781710978b0baa3e3bc99410d1973"
+                "reference": "7a4f1720c4fe1f0731254a82e63060a217f51cdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craftcms/server-check/zipball/3b1f239c1cc781710978b0baa3e3bc99410d1973",
-                "reference": "3b1f239c1cc781710978b0baa3e3bc99410d1973",
+                "url": "https://api.github.com/repos/craftcms/server-check/zipball/7a4f1720c4fe1f0731254a82e63060a217f51cdc",
+                "reference": "7a4f1720c4fe1f0731254a82e63060a217f51cdc",
                 "shasum": ""
             },
             "type": "library",
@@ -696,7 +694,7 @@
                 "rss": "https://github.com/craftcms/server-check/releases.atom",
                 "source": "https://github.com/craftcms/server-check"
             },
-            "time": "2025-07-23T14:22:43+00:00"
+            "time": "2026-04-07T16:48:35+00:00"
         },
         {
             "name": "creocoder/yii2-nested-sets",
@@ -2927,16 +2925,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.5.0",
+            "version": "5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "eecd31b885a1c8192f12738130f85bbc6e8906ba"
+                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/eecd31b885a1c8192f12738130f85bbc6e8906ba",
-                "reference": "eecd31b885a1c8192f12738130f85bbc6e8906ba",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
+                "reference": "9f55d3b9b7bcb1084fda8340e4b7ce4ed10cd0c8",
                 "shasum": ""
             },
             "require": {
@@ -3030,9 +3028,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.5.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.7.0"
             },
-            "time": "2026-03-01T00:58:56+00:00"
+            "time": "2026-04-20T02:42:17+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -3080,6 +3078,70 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "pixelandtonic/graphql-php",
+            "version": "v14.11.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pixelandtonic/graphql-php.git",
+                "reference": "fdb4a288878fc9ee449245e17209d676fc7c57fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pixelandtonic/graphql-php/zipball/fdb4a288878fc9ee449245e17209d676fc7c57fd",
+                "reference": "fdb4a288878fc9ee449245e17209d676fc7c57fd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.3",
+                "doctrine/coding-standard": "^6.0",
+                "nyholm/psr7": "^1.2",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "0.12.82",
+                "phpstan/phpstan-phpunit": "0.12.18",
+                "phpstan/phpstan-strict-rules": "0.12.9",
+                "phpunit/phpunit": "^7.2 || ^8.5",
+                "psr/http-message": "^1.0",
+                "react/promise": "2.*",
+                "simpod/php-coveralls-mirror": "^3.0"
+            },
+            "suggest": {
+                "psr/http-message": "To use standard GraphQL server",
+                "react/promise": "To leverage async resolving on React PHP platform"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GraphQL\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A PHP port of GraphQL reference implementation",
+            "homepage": "https://github.com/webonyx/graphql-php",
+            "keywords": [
+                "api",
+                "graphql"
+            ],
+            "support": {
+                "source": "https://github.com/pixelandtonic/graphql-php/tree/v14.11.10.1"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/webonyx-graphql-php",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2026-04-14T15:27:52+00:00"
         },
         {
             "name": "pixelandtonic/imagine",
@@ -3904,20 +3966,20 @@
         },
         {
             "name": "spomky-labs/cbor-php",
-            "version": "3.2.2",
+            "version": "3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/cbor-php.git",
-                "reference": "2a5fb86aacfe1004611370ead6caa2bfc88435d0"
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/2a5fb86aacfe1004611370ead6caa2bfc88435d0",
-                "reference": "2a5fb86aacfe1004611370ead6caa2bfc88435d0",
+                "url": "https://api.github.com/repos/Spomky-Labs/cbor-php/zipball/dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
+                "reference": "dd6eb84e6d92f7b8bd0da56b4b4dd7235aed0c32",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14",
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
                 "ext-mbstring": "*",
                 "php": ">=8.0"
             },
@@ -3959,7 +4021,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Spomky-Labs/cbor-php/issues",
-                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.2.2"
+                "source": "https://github.com/Spomky-Labs/cbor-php/tree/3.2.3"
             },
             "funding": [
                 {
@@ -3971,7 +4033,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-11-13T13:00:34+00:00"
+            "time": "2026-04-01T12:15:20+00:00"
         },
         {
             "name": "spomky-labs/pki-framework",
@@ -4085,16 +4147,16 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v7.4.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "9169f24776edde469914c1e7a1442a50f7a4e110"
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/9169f24776edde469914c1e7a1442a50f7a4e110",
-                "reference": "9169f24776edde469914c1e7a1442a50f7a4e110",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111",
                 "shasum": ""
             },
             "require": {
@@ -4139,7 +4201,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.4.0"
+                "source": "https://github.com/symfony/clock/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4159,20 +4221,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "2e7c52c647b406e2107dd867db424a4dbac91864"
+                "reference": "b055f228a4178a1d6774909903905e3475f3eac8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/2e7c52c647b406e2107dd867db424a4dbac91864",
-                "reference": "2e7c52c647b406e2107dd867db424a4dbac91864",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b055f228a4178a1d6774909903905e3475f3eac8",
+                "reference": "b055f228a4178a1d6774909903905e3475f3eac8",
                 "shasum": ""
             },
             "require": {
@@ -4208,7 +4270,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.4.6"
+                "source": "https://github.com/symfony/css-selector/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4228,7 +4290,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T07:53:42+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4299,16 +4361,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "487ba8fa43da9a8e6503fe939b45ecd96875410e"
+                "reference": "2918e7c2ba964defca1f5b69c6f74886529e2dc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/487ba8fa43da9a8e6503fe939b45ecd96875410e",
-                "reference": "487ba8fa43da9a8e6503fe939b45ecd96875410e",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/2918e7c2ba964defca1f5b69c6f74886529e2dc8",
+                "reference": "2918e7c2ba964defca1f5b69c6f74886529e2dc8",
                 "shasum": ""
             },
             "require": {
@@ -4347,7 +4409,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v7.4.6"
+                "source": "https://github.com/symfony/dom-crawler/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4367,20 +4429,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T07:53:42+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746"
+                "reference": "f57b899fa736fd71121168ef268f23c206083f0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/dc2c0eba1af673e736bb851d747d266108aea746",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f57b899fa736fd71121168ef268f23c206083f0a",
+                "reference": "f57b899fa736fd71121168ef268f23c206083f0a",
                 "shasum": ""
             },
             "require": {
@@ -4432,7 +4494,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.4"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4452,7 +4514,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T11:45:34+00:00"
+            "time": "2026-03-30T13:54:39+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -4602,16 +4664,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "1010624285470eb60e88ed10035102c75b4ea6af"
+                "reference": "01933e626c3de76bea1e22641e205e78f6a34342"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/1010624285470eb60e88ed10035102c75b4ea6af",
-                "reference": "1010624285470eb60e88ed10035102c75b4ea6af",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/01933e626c3de76bea1e22641e205e78f6a34342",
+                "reference": "01933e626c3de76bea1e22641e205e78f6a34342",
                 "shasum": ""
             },
             "require": {
@@ -4679,7 +4741,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.7"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4699,7 +4761,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-05T11:16:58+00:00"
+            "time": "2026-03-30T12:55:43+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -4781,16 +4843,16 @@
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9"
+                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
-                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
                 "shasum": ""
             },
             "require": {
@@ -4841,7 +4903,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.6"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4861,20 +4923,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1"
+                "reference": "6df02f99998081032da3407a8d6c4e1dcb5d4379"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
-                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/6df02f99998081032da3407a8d6c4e1dcb5d4379",
+                "reference": "6df02f99998081032da3407a8d6c4e1dcb5d4379",
                 "shasum": ""
             },
             "require": {
@@ -4930,7 +4992,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.7"
+                "source": "https://github.com/symfony/mime/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4950,20 +5012,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-05T15:24:09+00:00"
+            "time": "2026-03-30T14:11:46+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -5013,7 +5075,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5033,20 +5095,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
                 "shasum": ""
             },
             "require": {
@@ -5095,7 +5157,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5115,11 +5177,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -5182,7 +5244,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5206,7 +5268,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -5267,7 +5329,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5291,16 +5353,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -5352,7 +5414,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5372,20 +5434,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -5436,7 +5498,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5456,20 +5518,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
                 "shasum": ""
             },
             "require": {
@@ -5516,7 +5578,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5536,20 +5598,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
                 "shasum": ""
             },
             "require": {
@@ -5596,7 +5658,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5616,20 +5678,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-04-10T18:47:49+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -5679,7 +5741,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -5699,20 +5761,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.5",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
                 "shasum": ""
             },
             "require": {
@@ -5744,7 +5806,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.5"
+                "source": "https://github.com/symfony/process/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -5764,20 +5826,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/property-access",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-access.git",
-                "reference": "fa49bf1ca8fce1ba0e2dba4e4658554cfb9364b1"
+                "reference": "b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-access/zipball/fa49bf1ca8fce1ba0e2dba4e4658554cfb9364b1",
-                "reference": "fa49bf1ca8fce1ba0e2dba4e4658554cfb9364b1",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc",
+                "reference": "b7dad9dae8b8a47ef7ecc76c8569e7d8c7d90cfc",
                 "shasum": ""
             },
             "require": {
@@ -5825,7 +5887,7 @@
                 "reflection"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-access/tree/v7.4.4"
+                "source": "https://github.com/symfony/property-access/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -5845,20 +5907,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T08:47:25+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/property-info",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/property-info.git",
-                "reference": "02501d75fd834345da3ecdd8e3200ced39e370f8"
+                "reference": "ac5e82528b986c4f7cfccbf7764b5d2e824d6175"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/property-info/zipball/02501d75fd834345da3ecdd8e3200ced39e370f8",
-                "reference": "02501d75fd834345da3ecdd8e3200ced39e370f8",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/ac5e82528b986c4f7cfccbf7764b5d2e824d6175",
+                "reference": "ac5e82528b986c4f7cfccbf7764b5d2e824d6175",
                 "shasum": ""
             },
             "require": {
@@ -5915,7 +5977,7 @@
                 "validator"
             ],
             "support": {
-                "source": "https://github.com/symfony/property-info/tree/v7.4.7"
+                "source": "https://github.com/symfony/property-info/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -5935,20 +5997,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-04T15:53:26+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "bd395bbc6fabd136a48e1a6f91b09f88b5050b0b"
+                "reference": "006fd51717addf2df2bd1a64dafef6b7fab6b455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/bd395bbc6fabd136a48e1a6f91b09f88b5050b0b",
-                "reference": "bd395bbc6fabd136a48e1a6f91b09f88b5050b0b",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/006fd51717addf2df2bd1a64dafef6b7fab6b455",
+                "reference": "006fd51717addf2df2bd1a64dafef6b7fab6b455",
                 "shasum": ""
             },
             "require": {
@@ -6019,7 +6081,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v7.4.7"
+                "source": "https://github.com/symfony/serializer/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6039,7 +6101,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T13:15:18+00:00"
+            "time": "2026-03-30T21:34:42+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6130,16 +6192,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "9f209231affa85aa930a5e46e6eb03381424b30b"
+                "reference": "114ac57257d75df748eda23dd003878080b8e688"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/9f209231affa85aa930a5e46e6eb03381424b30b",
-                "reference": "9f209231affa85aa930a5e46e6eb03381424b30b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
+                "reference": "114ac57257d75df748eda23dd003878080b8e688",
                 "shasum": ""
             },
             "require": {
@@ -6197,7 +6259,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.6"
+                "source": "https://github.com/symfony/string/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6217,7 +6279,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/translation",
@@ -6402,16 +6464,16 @@
         },
         {
             "name": "symfony/type-info",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "31f1e40cbf7851c7354281c90eb1b352c4cb8269"
+                "reference": "6bf34da885ff5143a3dfd8f1b863bb8ab95f50bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/31f1e40cbf7851c7354281c90eb1b352c4cb8269",
-                "reference": "31f1e40cbf7851c7354281c90eb1b352c4cb8269",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/6bf34da885ff5143a3dfd8f1b863bb8ab95f50bd",
+                "reference": "6bf34da885ff5143a3dfd8f1b863bb8ab95f50bd",
                 "shasum": ""
             },
             "require": {
@@ -6461,7 +6523,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v7.4.7"
+                "source": "https://github.com/symfony/type-info/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6481,20 +6543,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-04T12:49:16+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v7.4.4",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36"
+                "reference": "6883ebdf7bf6a12b37519dbc0df62b0222401b56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/7719ce8aba76be93dfe249192f1fbfa52c588e36",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/6883ebdf7bf6a12b37519dbc0df62b0222401b56",
+                "reference": "6883ebdf7bf6a12b37519dbc0df62b0222401b56",
                 "shasum": ""
             },
             "require": {
@@ -6539,7 +6601,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.4"
+                "source": "https://github.com/symfony/uid/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6559,20 +6621,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-03T23:30:35+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291"
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/045321c440ac18347b136c63d2e9bf28a2dc0291",
-                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
                 "shasum": ""
             },
             "require": {
@@ -6626,7 +6688,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.6"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6646,20 +6708,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-15T10:53:20+00:00"
+            "time": "2026-03-30T13:44:50+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391"
+                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/58751048de17bae71c5aa0d13cb19d79bca26391",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
+                "reference": "c58fdf7b3d6c2995368264c49e4e8b05bcff2883",
                 "shasum": ""
             },
             "require": {
@@ -6702,7 +6764,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.6"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -6722,7 +6784,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "theiconic/name-parser",
@@ -6853,23 +6915,23 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "d870a33f0f79d2b4579740b0620200221ee44aeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/d870a33f0f79d2b4579740b0620200221ee44aeb",
+                "reference": "d870a33f0f79d2b4579740b0620200221ee44aeb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -6899,7 +6961,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.0"
             },
             "funding": [
                 {
@@ -6923,24 +6985,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-16T23:10:39+00:00"
         },
         {
             "name": "web-auth/cose-lib",
-            "version": "4.5.0",
+            "version": "4.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-auth/cose-lib.git",
-                "reference": "5adac6fe126994a3ee17ed9950efb4947ab132a9"
+                "reference": "3185af4df10dc537b65c140c315b88d15ae15b80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-auth/cose-lib/zipball/5adac6fe126994a3ee17ed9950efb4947ab132a9",
-                "reference": "5adac6fe126994a3ee17ed9950efb4947ab132a9",
+                "url": "https://api.github.com/repos/web-auth/cose-lib/zipball/3185af4df10dc537b65c140c315b88d15ae15b80",
+                "reference": "3185af4df10dc537b65c140c315b88d15ae15b80",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14",
+                "brick/math": "^0.9|^0.10|^0.11|^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
                 "ext-json": "*",
                 "ext-openssl": "*",
                 "php": ">=8.1",
@@ -6982,7 +7044,7 @@
             ],
             "support": {
                 "issues": "https://github.com/web-auth/cose-lib/issues",
-                "source": "https://github.com/web-auth/cose-lib/tree/4.5.0"
+                "source": "https://github.com/web-auth/cose-lib/tree/4.5.1"
             },
             "funding": [
                 {
@@ -6994,7 +7056,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-01-03T14:43:18+00:00"
+            "time": "2026-04-01T12:47:39+00:00"
         },
         {
             "name": "web-auth/webauthn-lib",
@@ -7139,71 +7201,6 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.12.1"
             },
             "time": "2025-10-29T15:56:20+00:00"
-        },
-        {
-            "name": "webonyx/graphql-php",
-            "version": "v14.11.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/d9c2fdebc6aa01d831bc2969da00e8588cffef19",
-                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": "^7.1 || ^8"
-            },
-            "require-dev": {
-                "amphp/amp": "^2.3",
-                "doctrine/coding-standard": "^6.0",
-                "nyholm/psr7": "^1.2",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "0.12.82",
-                "phpstan/phpstan-phpunit": "0.12.18",
-                "phpstan/phpstan-strict-rules": "0.12.9",
-                "phpunit/phpunit": "^7.2 || ^8.5",
-                "psr/http-message": "^1.0",
-                "react/promise": "2.*",
-                "simpod/php-coveralls-mirror": "^3.0"
-            },
-            "suggest": {
-                "psr/http-message": "To use standard GraphQL server",
-                "react/promise": "To leverage async resolving on React PHP platform"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "GraphQL\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A PHP port of GraphQL reference implementation",
-            "homepage": "https://github.com/webonyx/graphql-php",
-            "keywords": [
-                "api",
-                "graphql"
-            ],
-            "support": {
-                "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.10"
-            },
-            "funding": [
-                {
-                    "url": "https://opencollective.com/webonyx-graphql-php",
-                    "type": "open_collective"
-                }
-            ],
-            "time": "2023-07-05T14:23:37+00:00"
         },
         {
             "name": "yiisoft/yii2",
@@ -7828,6 +7825,75 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "ergebnis/agent-detector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/agent-detector.git",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/agent-detector/zipball/5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.50.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.16.0",
+                "fakerphp/faker": "^1.24.1",
+                "infection/infection": "^0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.46",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a detector for detecting the presence of an agent.",
+            "homepage": "https://github.com/ergebnis/agent-detector",
+            "support": {
+                "issues": "https://github.com/ergebnis/agent-detector/issues",
+                "security": "https://github.com/ergebnis/agent-detector/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/agent-detector"
+            },
+            "time": "2026-04-10T13:45:13+00:00"
+        },
+        {
             "name": "evenement/evenement",
             "version": "v3.0.2",
             "source": {
@@ -8089,22 +8155,23 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.94.2",
+            "version": "v3.95.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63"
+                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/7787ceff91365ba7d623ec410b8f429cdebb4f63",
-                "reference": "7787ceff91365ba7d623ec410b8f429cdebb4f63",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a9727678fbd12997f1d9de8f4a37824ed9df1065",
+                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065",
                 "shasum": ""
             },
             "require": {
                 "clue/ndjson-react": "^1.3",
                 "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.5",
+                "ergebnis/agent-detector": "^1.1.1",
                 "ext-filter": "*",
                 "ext-hash": "*",
                 "ext-json": "*",
@@ -8129,18 +8196,18 @@
                 "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.7.1",
-                "infection/infection": "^0.32.3",
-                "justinrainbow/json-schema": "^6.6.4",
+                "facile-it/paraunit": "^1.3.1 || ^2.8.0",
+                "infection/infection": "^0.32.6",
+                "justinrainbow/json-schema": "^6.8.0",
                 "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.9.1",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.7",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.7",
-                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.51",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
                 "symfony/polyfill-php85": "^1.33",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.4",
-                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.1"
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.8"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -8181,7 +8248,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.94.2"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.1"
             },
             "funding": [
                 {
@@ -8189,7 +8256,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-20T16:13:53+00:00"
+            "time": "2026-04-12T17:00:09+00:00"
         },
         {
             "name": "humbug/php-scoper",
@@ -8651,11 +8718,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.45",
+            "version": "2.1.51",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f8cdfd9421b7edb7686a2d150a234870464eac70",
-                "reference": "f8cdfd9421b7edb7686a2d150a234870464eac70",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc3b523c45e714c70de2ac5113b958223b55dc59",
+                "reference": "dc3b523c45e714c70de2ac5113b958223b55dc59",
                 "shasum": ""
             },
             "require": {
@@ -8700,7 +8767,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-30T13:22:02+00:00"
+            "time": "2026-04-21T18:22:01+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
@@ -9794,21 +9861,21 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.3.9",
+            "version": "2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "917842143fd9f5331a2adefc214b8d7143bd32c4"
+                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/917842143fd9f5331a2adefc214b8d7143bd32c4",
-                "reference": "917842143fd9f5331a2adefc214b8d7143bd32c4",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e645b6463c6a88ea5b44b17d3387d35a912c7946",
+                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.40"
+                "phpstan/phpstan": "^2.1.48"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -9842,7 +9909,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.3.9"
+                "source": "https://github.com/rectorphp/rector/tree/2.4.2"
             },
             "funding": [
                 {
@@ -9850,7 +9917,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-16T09:43:55+00:00"
+            "time": "2026-04-16T13:07:34+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -10958,16 +11025,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
                 "shasum": ""
             },
             "require": {
@@ -11032,7 +11099,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.7"
+                "source": "https://github.com/symfony/console/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -11052,20 +11119,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T14:06:20+00:00"
+            "time": "2026-03-30T13:54:39+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.6",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf"
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
+                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
                 "shasum": ""
             },
             "require": {
@@ -11100,7 +11167,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.6"
+                "source": "https://github.com/symfony/finder/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -11120,20 +11187,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T09:40:50+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.4.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "b38026df55197f9e39a44f3215788edf83187b80"
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b38026df55197f9e39a44f3215788edf83187b80",
-                "reference": "b38026df55197f9e39a44f3215788edf83187b80",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
                 "shasum": ""
             },
             "require": {
@@ -11171,7 +11238,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.4.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -11191,11 +11258,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.33.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -11251,7 +11318,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -11275,16 +11342,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.4.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "8a24af0a2e8a872fb745047180649b8418303084"
+                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/8a24af0a2e8a872fb745047180649b8418303084",
-                "reference": "8a24af0a2e8a872fb745047180649b8418303084",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
                 "shasum": ""
             },
             "require": {
@@ -11317,7 +11384,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.4.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -11337,7 +11404,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-04T07:05:15+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "thecodingmachine/safe",
@@ -11592,7 +11659,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -11600,9 +11667,9 @@
         "ext-libxml": "*",
         "ext-simplexml": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/dependencies/simplehtmldom/src/simple_html_dom.php
+++ b/dependencies/simplehtmldom/src/simple_html_dom.php
@@ -102,7 +102,7 @@ function str_get_html($str, $lowercase = true, $forceTagsClosed = true, $target_
 }
 
 // dump html dom tree
-function dump_html_tree($node, $show_attr = true, $deep = 0)
+function dump_html_tree($node, $show_attr = true, $deep = 0): void
 {
     $node->dump($node);
 }
@@ -142,7 +142,7 @@ class simple_html_dom_node
     }
 
     // clean up memory due to php5 circular references memory leak...
-    public function clear()
+    public function clear(): void
     {
         $this->dom = null;
         $this->nodes = null;
@@ -151,7 +151,7 @@ class simple_html_dom_node
     }
 
     // dump node's tree
-    public function dump($show_attr = true, $deep = 0)
+    public function dump($show_attr = true, $deep = 0): void
     {
         $lead = str_repeat('    ', $deep);
 
@@ -571,7 +571,7 @@ class simple_html_dom_node
 
     // seek for given conditions
     // PaperG - added parameter to allow for case insensitive testing of the value of a selector.
-    protected function seek($selector, &$ret, $lowercase = false, $direct = false)
+    protected function seek($selector, &$ret, $lowercase = false, $direct = false): void
     {
         global $debugObject;
         if (\is_object($debugObject)) {
@@ -849,7 +849,7 @@ class simple_html_dom_node
         return (\array_key_exists($name, $this->attr)) ? true : isset($this->attr[$name]);
     }
 
-    public function __unset($name)
+    public function __unset($name): void
     {
         if (isset($this->attr[$name])) {
             unset($this->attr[$name]);
@@ -1045,7 +1045,7 @@ class simple_html_dom_node
         return $this->__get($name);
     }
 
-    public function setAttribute($name, $value)
+    public function setAttribute($name, $value): void
     {
         $this->__set($name, $value);
     }
@@ -1055,7 +1055,7 @@ class simple_html_dom_node
         return $this->__isset($name);
     }
 
-    public function removeAttribute($name)
+    public function removeAttribute($name): void
     {
         $this->__set($name, null);
     }
@@ -1270,13 +1270,13 @@ class simple_html_dom
     }
 
     // set callback function
-    public function set_callback($function_name)
+    public function set_callback($function_name): void
     {
         $this->callback = $function_name;
     }
 
     // remove callback function
-    public function remove_callback()
+    public function remove_callback(): void
     {
         $this->callback = null;
     }
@@ -1304,7 +1304,7 @@ class simple_html_dom
     }
 
     // clean up memory due to php5 circular references memory leak...
-    public function clear()
+    public function clear(): void
     {
         foreach ($this->nodes as $n) {
             $n->clear();
@@ -1329,13 +1329,13 @@ class simple_html_dom
         unset($this->noise);
     }
 
-    public function dump($show_attr = true)
+    public function dump($show_attr = true): void
     {
         $this->root->dump($show_attr);
     }
 
     // prepare HTML data and init everything
-    protected function prepare($str, $lowercase = true, $stripRN = true, $defaultBRText = WG_DEFAULT_BR_TEXT, $defaultSpanText = WG_DEFAULT_SPAN_TEXT)
+    protected function prepare($str, $lowercase = true, $stripRN = true, $defaultBRText = WG_DEFAULT_BR_TEXT, $defaultSpanText = WG_DEFAULT_SPAN_TEXT): void
     {
         $this->clear();
 
@@ -1698,7 +1698,7 @@ class simple_html_dom
     }
 
     // parse attributes
-    protected function parse_attr($node, $name, &$space)
+    protected function parse_attr($node, $name, &$space): void
     {
         // Per sourceforge: http://sourceforge.net/tracker/?func=detail&aid=3061408&group_id=218559&atid=1044037
         // If the attribute is already defined inside a tag, only pay atetntion to the first one as opposed to the last one.
@@ -1734,7 +1734,7 @@ class simple_html_dom
     }
 
     // link node's parent
-    protected function link_nodes(&$node, $is_child)
+    protected function link_nodes(&$node, $is_child): void
     {
         $node->parent = $this->parent;
         $this->parent->nodes[] = $node;
@@ -1755,7 +1755,7 @@ class simple_html_dom
         return true;
     }
 
-    protected function skip($chars)
+    protected function skip($chars): void
     {
         $this->pos += strspn($this->doc, $chars, $this->pos);
         $this->char = ($this->pos < $this->size) ? $this->doc[$this->pos] : null; // next
@@ -1843,7 +1843,7 @@ class simple_html_dom
 
     // remove noise from html content
     // save the noise in the $this->noise array.
-    protected function remove_noise($pattern, $remove_tag = false)
+    protected function remove_noise($pattern, $remove_tag = false): void
     {
         global $debugObject;
         if (\is_object($debugObject)) {
@@ -1982,7 +1982,7 @@ class simple_html_dom
         return $this->find($name, $idx);
     }
 
-    public function loadFile()
+    public function loadFile(): void
     {
         $args = \func_get_args();
         $this->load_file($args);

--- a/dependencies/simplehtmldom/src/simple_html_dom.php
+++ b/dependencies/simplehtmldom/src/simple_html_dom.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WGSimpleHtmlDom;
 
 /*

--- a/dependencies/translation-definitions/index.php
+++ b/dependencies/translation-definitions/index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot;
 
 class index

--- a/dependencies/translation-definitions/index.php
+++ b/dependencies/translation-definitions/index.php
@@ -24,7 +24,7 @@ class index
         return $array;
     }
 
-    public static function init()
+    public static function init(): void
     {
         self::$languages = array_map(static function ($language) {
             return [

--- a/dependencies/weglot-php/src/Client/Api/Enum/BotType.php
+++ b/dependencies/weglot-php/src/Client/Api/Enum/BotType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Enum;
 
 /**

--- a/dependencies/weglot-php/src/Client/Api/Enum/WordType.php
+++ b/dependencies/weglot-php/src/Client/Api/Enum/WordType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Enum;
 
 /**

--- a/dependencies/weglot-php/src/Client/Api/Exception/AbstractException.php
+++ b/dependencies/weglot-php/src/Client/Api/Exception/AbstractException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Exception;
 
 abstract class AbstractException extends \Exception

--- a/dependencies/weglot-php/src/Client/Api/Exception/ApiError.php
+++ b/dependencies/weglot-php/src/Client/Api/Exception/ApiError.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Exception;
 
 class ApiError extends AbstractException

--- a/dependencies/weglot-php/src/Client/Api/Exception/InputAndOutputCountMatchException.php
+++ b/dependencies/weglot-php/src/Client/Api/Exception/InputAndOutputCountMatchException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Exception;
 
 class InputAndOutputCountMatchException extends AbstractException

--- a/dependencies/weglot-php/src/Client/Api/Exception/InvalidLanguageException.php
+++ b/dependencies/weglot-php/src/Client/Api/Exception/InvalidLanguageException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Exception;
 
 class InvalidLanguageException extends AbstractException

--- a/dependencies/weglot-php/src/Client/Api/Exception/InvalidWordTypeException.php
+++ b/dependencies/weglot-php/src/Client/Api/Exception/InvalidWordTypeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Exception;
 
 class InvalidWordTypeException extends AbstractException

--- a/dependencies/weglot-php/src/Client/Api/Exception/MissingRequiredParamException.php
+++ b/dependencies/weglot-php/src/Client/Api/Exception/MissingRequiredParamException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Exception;
 
 class MissingRequiredParamException extends AbstractException

--- a/dependencies/weglot-php/src/Client/Api/Exception/MissingWordsOutputException.php
+++ b/dependencies/weglot-php/src/Client/Api/Exception/MissingWordsOutputException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Exception;
 
 class MissingWordsOutputException extends \Exception

--- a/dependencies/weglot-php/src/Client/Api/Exception/WeglotCode.php
+++ b/dependencies/weglot-php/src/Client/Api/Exception/WeglotCode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Exception;
 
 abstract class WeglotCode

--- a/dependencies/weglot-php/src/Client/Api/LanguageCollection.php
+++ b/dependencies/weglot-php/src/Client/Api/LanguageCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api;
 
 use Weglot\Client\Api\Shared\AbstractCollection;

--- a/dependencies/weglot-php/src/Client/Api/LanguageEntry.php
+++ b/dependencies/weglot-php/src/Client/Api/LanguageEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api;
 
 use Weglot\Client\Api\Shared\AbstractCollectionEntry;

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollection.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Shared;
 
 /**

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionArrayAccess.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionArrayAccess.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Shared;
 
 trait AbstractCollectionArrayAccess

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionArrayAccess.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionArrayAccess.php
@@ -17,7 +17,7 @@ trait AbstractCollectionArrayAccess
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (isset($this->collection[$offset]) && $value instanceof AbstractCollectionEntry) {
             $this->collection[$offset] = $value;
@@ -25,7 +25,7 @@ trait AbstractCollectionArrayAccess
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->collection[$offset]);
     }

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionCountable.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionCountable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Shared;
 
 trait AbstractCollectionCountable

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionEntry.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Shared;
 
 abstract class AbstractCollectionEntry implements \JsonSerializable

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionInterface.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Shared;
 
 /**

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionIterator.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Shared;
 
 trait AbstractCollectionIterator

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionIterator.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionIterator.php
@@ -11,7 +11,7 @@ trait AbstractCollectionIterator
     }
 
     #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         next($this->collection);
     }
@@ -29,7 +29,7 @@ trait AbstractCollectionIterator
     }
 
     #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->collection);
     }

--- a/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionSerializable.php
+++ b/dependencies/weglot-php/src/Client/Api/Shared/AbstractCollectionSerializable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api\Shared;
 
 trait AbstractCollectionSerializable

--- a/dependencies/weglot-php/src/Client/Api/TranslateEntry.php
+++ b/dependencies/weglot-php/src/Client/Api/TranslateEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api;
 
 use Weglot\Client\Api\Exception\MissingRequiredParamException;

--- a/dependencies/weglot-php/src/Client/Api/WordCollection.php
+++ b/dependencies/weglot-php/src/Client/Api/WordCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api;
 
 use Weglot\Client\Api\Shared\AbstractCollection;

--- a/dependencies/weglot-php/src/Client/Api/WordEntry.php
+++ b/dependencies/weglot-php/src/Client/Api/WordEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Api;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Client/Caching/Cache.php
+++ b/dependencies/weglot-php/src/Client/Caching/Cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Caching;
 
 use Psr\Cache\CacheItemInterface;

--- a/dependencies/weglot-php/src/Client/Caching/CacheInterface.php
+++ b/dependencies/weglot-php/src/Client/Caching/CacheInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Caching;
 
 use Psr\Cache\CacheItemInterface;

--- a/dependencies/weglot-php/src/Client/Client.php
+++ b/dependencies/weglot-php/src/Client/Client.php
@@ -76,8 +76,6 @@ class Client
 
     /**
      * Creating Guzzle HTTP connector based on $options.
-     *
-     * @return void
      */
     protected function setupConnector(): void
     {

--- a/dependencies/weglot-php/src/Client/Client.php
+++ b/dependencies/weglot-php/src/Client/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client;
 
 use Psr\Cache\CacheItemPoolInterface;

--- a/dependencies/weglot-php/src/Client/Client.php
+++ b/dependencies/weglot-php/src/Client/Client.php
@@ -79,7 +79,7 @@ class Client
      *
      * @return void
      */
-    protected function setupConnector()
+    protected function setupConnector(): void
     {
         $this->httpClient = new CurlClient();
     }

--- a/dependencies/weglot-php/src/Client/Endpoint/CdnTranslate.php
+++ b/dependencies/weglot-php/src/Client/Endpoint/CdnTranslate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Endpoint;
 
 use Weglot\Client\Api\Exception\ApiError;

--- a/dependencies/weglot-php/src/Client/Endpoint/Endpoint.php
+++ b/dependencies/weglot-php/src/Client/Endpoint/Endpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Endpoint;
 
 use Weglot\Client\Api\Exception\ApiError;

--- a/dependencies/weglot-php/src/Client/Endpoint/Endpoint.php
+++ b/dependencies/weglot-php/src/Client/Endpoint/Endpoint.php
@@ -24,7 +24,7 @@ abstract class Endpoint
     /**
      * @return void
      */
-    public function setClient(Client $client)
+    public function setClient(Client $client): void
     {
         $this->client = $client;
     }

--- a/dependencies/weglot-php/src/Client/Endpoint/Endpoint.php
+++ b/dependencies/weglot-php/src/Client/Endpoint/Endpoint.php
@@ -21,9 +21,6 @@ abstract class Endpoint
         $this->setClient($client);
     }
 
-    /**
-     * @return void
-     */
     public function setClient(Client $client): void
     {
         $this->client = $client;

--- a/dependencies/weglot-php/src/Client/Endpoint/LanguagesList.php
+++ b/dependencies/weglot-php/src/Client/Endpoint/LanguagesList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Endpoint;
 
 use Weglot\Client\Api\LanguageCollection;

--- a/dependencies/weglot-php/src/Client/Endpoint/Status.php
+++ b/dependencies/weglot-php/src/Client/Endpoint/Status.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Endpoint;
 
 use Weglot\Client\Api\Exception\ApiError;

--- a/dependencies/weglot-php/src/Client/Endpoint/Translate.php
+++ b/dependencies/weglot-php/src/Client/Endpoint/Translate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Endpoint;
 
 use Weglot\Client\Api\Exception\ApiError;

--- a/dependencies/weglot-php/src/Client/Factory/Languages.php
+++ b/dependencies/weglot-php/src/Client/Factory/Languages.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Factory;
 
 use Weglot\Client\Api\LanguageEntry;

--- a/dependencies/weglot-php/src/Client/Factory/Translate.php
+++ b/dependencies/weglot-php/src/Client/Factory/Translate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\Factory;
 
 use Weglot\Client\Api\Exception\InputAndOutputCountMatchException;

--- a/dependencies/weglot-php/src/Client/HttpClient/ClientInterface.php
+++ b/dependencies/weglot-php/src/Client/HttpClient/ClientInterface.php
@@ -10,7 +10,7 @@ interface ClientInterface
      *
      * @return void
      */
-    public function addUserAgentInfo($service, $value);
+    public function addUserAgentInfo($service, $value): void;
 
     /**
      * @return array<string, string>
@@ -22,7 +22,7 @@ interface ClientInterface
      *
      * @return void
      */
-    public function addHeader($header);
+    public function addHeader($header): void;
 
     /**
      * @return array<string>

--- a/dependencies/weglot-php/src/Client/HttpClient/ClientInterface.php
+++ b/dependencies/weglot-php/src/Client/HttpClient/ClientInterface.php
@@ -7,8 +7,6 @@ interface ClientInterface
     /**
      * @param string $service
      * @param string $value
-     *
-     * @return void
      */
     public function addUserAgentInfo($service, $value): void;
 
@@ -19,8 +17,6 @@ interface ClientInterface
 
     /**
      * @param string $header
-     *
-     * @return void
      */
     public function addHeader($header): void;
 

--- a/dependencies/weglot-php/src/Client/HttpClient/ClientInterface.php
+++ b/dependencies/weglot-php/src/Client/HttpClient/ClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\HttpClient;
 
 interface ClientInterface

--- a/dependencies/weglot-php/src/Client/HttpClient/CurlClient.php
+++ b/dependencies/weglot-php/src/Client/HttpClient/CurlClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client\HttpClient;
 
 // @codingStandardsIgnoreStart

--- a/dependencies/weglot-php/src/Client/HttpClient/CurlClient.php
+++ b/dependencies/weglot-php/src/Client/HttpClient/CurlClient.php
@@ -70,8 +70,6 @@ class CurlClient implements ClientInterface
 
     /**
      * Initializing default user-agent.
-     *
-     * @return void
      */
     public function initUserAgentInfo(): void
     {
@@ -92,8 +90,6 @@ class CurlClient implements ClientInterface
 
     /**
      * @param string $header
-     *
-     * @return void
      */
     public function addHeader($header): void
     {
@@ -111,8 +107,6 @@ class CurlClient implements ClientInterface
     /**
      * @param string $service
      * @param string $value
-     *
-     * @return void
      */
     public function addUserAgentInfo($service, $value): void
     {

--- a/dependencies/weglot-php/src/Client/HttpClient/CurlClient.php
+++ b/dependencies/weglot-php/src/Client/HttpClient/CurlClient.php
@@ -73,7 +73,7 @@ class CurlClient implements ClientInterface
      *
      * @return void
      */
-    public function initUserAgentInfo()
+    public function initUserAgentInfo(): void
     {
         $curlVersion = curl_version();
         $this->userAgentInfo = [
@@ -95,7 +95,7 @@ class CurlClient implements ClientInterface
      *
      * @return void
      */
-    public function addHeader($header)
+    public function addHeader($header): void
     {
         $this->defaultHeaders[] = $header;
     }
@@ -114,7 +114,7 @@ class CurlClient implements ClientInterface
      *
      * @return void
      */
-    public function addUserAgentInfo($service, $value)
+    public function addUserAgentInfo($service, $value): void
     {
         $this->userAgentInfo[$service] = $value;
     }

--- a/dependencies/weglot-php/src/Client/Profile.php
+++ b/dependencies/weglot-php/src/Client/Profile.php
@@ -26,8 +26,6 @@ class Profile
     /**
      * @param string $apiKey
      * @param int    $translationEngine
-     *
-     * @return void
      */
     protected function setup($apiKey, $translationEngine): void
     {

--- a/dependencies/weglot-php/src/Client/Profile.php
+++ b/dependencies/weglot-php/src/Client/Profile.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Client;
 
 class Profile

--- a/dependencies/weglot-php/src/Client/Profile.php
+++ b/dependencies/weglot-php/src/Client/Profile.php
@@ -29,7 +29,7 @@ class Profile
      *
      * @return void
      */
-    protected function setup($apiKey, $translationEngine)
+    protected function setup($apiKey, $translationEngine): void
     {
         $apiKeyLength = \strlen($apiKey);
 

--- a/dependencies/weglot-php/src/Parser/Check/AbstractChecker.php
+++ b/dependencies/weglot-php/src/Parser/Check/AbstractChecker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check;
 
 use Weglot\Parser\Parser;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/AbstractDomChecker.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/AbstractDomChecker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/Button.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/Button.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/ExternalLinkHref.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/ExternalLinkHref.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/IframeSrc.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/IframeSrc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/ImageAlt.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/ImageAlt.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/ImageDataSource.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/ImageDataSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/ImageSource.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/ImageSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/ImageSourceSet.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/ImageSourceSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/InputButtonDataValue.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/InputButtonDataValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/InputButtonOrderText.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/InputButtonOrderText.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/InputRadioOrderText.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/InputRadioOrderText.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataContent.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataContent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataHover.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataHover.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataText.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataText.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataTitle.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataTitle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataTooltip.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataTooltip.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataValue.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/LinkDataValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/LinkHref.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/LinkHref.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/LinkTitle.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/LinkTitle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/MetaContent.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/MetaContent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/MetaTitleContent.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/MetaTitleContent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/Placeholder.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/Placeholder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/SpanTitle.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/SpanTitle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/TdDataTitle.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/TdDataTitle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/Dom/Text.php
+++ b/dependencies/weglot-php/src/Parser/Check/Dom/Text.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Dom;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/DomCheckerProvider.php
+++ b/dependencies/weglot-php/src/Parser/Check/DomCheckerProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Parser/Check/DomCheckerProvider.php
+++ b/dependencies/weglot-php/src/Parser/Check/DomCheckerProvider.php
@@ -203,7 +203,7 @@ class DomCheckerProvider
      *
      * @return void
      */
-    protected function loadDefaultCheckers()
+    protected function loadDefaultCheckers(): void
     {
         $files = array_diff(scandir(__DIR__.'/Dom'), ['AbstractDomChecker.php', '..', '.']);
         $checkers = array_map(static function ($filename) {
@@ -325,7 +325,7 @@ class DomCheckerProvider
      *
      * @throws InvalidWordTypeException
      */
-    public function handleOldEngine($discoveringNodes, &$nodes, $class, $property, $wordType)
+    public function handleOldEngine($discoveringNodes, &$nodes, $class, $property, $wordType): void
     {
         foreach ($discoveringNodes as $node) {
             $instance = new $class($node, $property);

--- a/dependencies/weglot-php/src/Parser/Check/DomCheckerProvider.php
+++ b/dependencies/weglot-php/src/Parser/Check/DomCheckerProvider.php
@@ -200,8 +200,6 @@ class DomCheckerProvider
 
     /**
      * Load default checkers.
-     *
-     * @return void
      */
     protected function loadDefaultCheckers(): void
     {
@@ -320,8 +318,6 @@ class DomCheckerProvider
      * @param class-string $class
      * @param string       $property
      * @param int          $wordType
-     *
-     * @return void
      *
      * @throws InvalidWordTypeException
      */

--- a/dependencies/weglot-php/src/Parser/Check/Regex/JsonChecker.php
+++ b/dependencies/weglot-php/src/Parser/Check/Regex/JsonChecker.php
@@ -127,8 +127,6 @@ class JsonChecker
      * @param string                                       $currentKey
      * @param array<array{key: int|string, parsed: array}> $paths
      *
-     * @return void
-     *
      * @throws InvalidWordTypeException
      */
     public function findWords($json, $currentKey, &$paths): void

--- a/dependencies/weglot-php/src/Parser/Check/Regex/JsonChecker.php
+++ b/dependencies/weglot-php/src/Parser/Check/Regex/JsonChecker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Regex;
 
 use Weglot\Client\Api\Exception\InvalidWordTypeException;

--- a/dependencies/weglot-php/src/Parser/Check/Regex/JsonChecker.php
+++ b/dependencies/weglot-php/src/Parser/Check/Regex/JsonChecker.php
@@ -131,7 +131,7 @@ class JsonChecker
      *
      * @throws InvalidWordTypeException
      */
-    public function findWords($json, $currentKey, &$paths)
+    public function findWords($json, $currentKey, &$paths): void
     {
         foreach ($json as $key => $value) {
             if (!\is_string($value)) {

--- a/dependencies/weglot-php/src/Parser/Check/Regex/RegexChecker.php
+++ b/dependencies/weglot-php/src/Parser/Check/Regex/RegexChecker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check\Regex;
 
 class RegexChecker

--- a/dependencies/weglot-php/src/Parser/Check/RegexCheckerProvider.php
+++ b/dependencies/weglot-php/src/Parser/Check/RegexCheckerProvider.php
@@ -82,8 +82,6 @@ class RegexCheckerProvider
 
     /**
      * Load default checkers.
-     *
-     * @return void
      */
     protected function loadDefaultCheckers(): void
     {

--- a/dependencies/weglot-php/src/Parser/Check/RegexCheckerProvider.php
+++ b/dependencies/weglot-php/src/Parser/Check/RegexCheckerProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Check;
 
 use Weglot\Client\Api\Exception\InvalidWordTypeException;

--- a/dependencies/weglot-php/src/Parser/Check/RegexCheckerProvider.php
+++ b/dependencies/weglot-php/src/Parser/Check/RegexCheckerProvider.php
@@ -85,7 +85,7 @@ class RegexCheckerProvider
      *
      * @return void
      */
-    protected function loadDefaultCheckers()
+    protected function loadDefaultCheckers(): void
     {
         $jsonKeys = ['description', 'name', 'headline', 'articleSection', 'text'];
 

--- a/dependencies/weglot-php/src/Parser/ConfigProvider/AbstractConfigProvider.php
+++ b/dependencies/weglot-php/src/Parser/ConfigProvider/AbstractConfigProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\ConfigProvider;
 
 abstract class AbstractConfigProvider implements ConfigProviderInterface

--- a/dependencies/weglot-php/src/Parser/ConfigProvider/ConfigProviderInterface.php
+++ b/dependencies/weglot-php/src/Parser/ConfigProvider/ConfigProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\ConfigProvider;
 
 interface ConfigProviderInterface

--- a/dependencies/weglot-php/src/Parser/ConfigProvider/ManualConfigProvider.php
+++ b/dependencies/weglot-php/src/Parser/ConfigProvider/ManualConfigProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\ConfigProvider;
 
 class ManualConfigProvider extends AbstractConfigProvider

--- a/dependencies/weglot-php/src/Parser/ConfigProvider/ServerConfigProvider.php
+++ b/dependencies/weglot-php/src/Parser/ConfigProvider/ServerConfigProvider.php
@@ -22,7 +22,7 @@ class ServerConfigProvider extends AbstractConfigProvider
      *
      * @return void
      */
-    public function loadFromServer($canonical = '')
+    public function loadFromServer($canonical = ''): void
     {
         if (!empty($canonical)) {
             $url = $canonical;

--- a/dependencies/weglot-php/src/Parser/ConfigProvider/ServerConfigProvider.php
+++ b/dependencies/weglot-php/src/Parser/ConfigProvider/ServerConfigProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\ConfigProvider;
 
 use Weglot\Client\Api\Enum\BotType;

--- a/dependencies/weglot-php/src/Parser/ConfigProvider/ServerConfigProvider.php
+++ b/dependencies/weglot-php/src/Parser/ConfigProvider/ServerConfigProvider.php
@@ -19,8 +19,6 @@ class ServerConfigProvider extends AbstractConfigProvider
      * Is used to load server data, you have to run it manually !
      *
      * @param string $canonical
-     *
-     * @return void
      */
     public function loadFromServer($canonical = ''): void
     {

--- a/dependencies/weglot-php/src/Parser/Formatter/AbstractFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/AbstractFormatter.php
@@ -62,8 +62,6 @@ abstract class AbstractFormatter
 
     /**
      * @param int $index
-     *
-     * @return void
      */
     abstract public function handle(array $array, &$index): void;
 }

--- a/dependencies/weglot-php/src/Parser/Formatter/AbstractFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/AbstractFormatter.php
@@ -65,5 +65,5 @@ abstract class AbstractFormatter
      *
      * @return void
      */
-    abstract public function handle(array $array, &$index);
+    abstract public function handle(array $array, &$index): void;
 }

--- a/dependencies/weglot-php/src/Parser/Formatter/AbstractFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/AbstractFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Formatter;
 
 use Weglot\Client\Api\TranslateEntry;

--- a/dependencies/weglot-php/src/Parser/Formatter/CustomSwitchersFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/CustomSwitchersFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Formatter;
 
 use WGSimpleHtmlDom\simple_html_dom;

--- a/dependencies/weglot-php/src/Parser/Formatter/DomFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/DomFormatter.php
@@ -66,8 +66,6 @@ class DomFormatter extends AbstractFormatter
      * @param array  $translatable_attributes
      * @param array  $original_words
      * @param array  $translated_words
-     *
-     * @return void
      */
     protected function metaContent(array $details, $translated, $translatable_attributes, $original_words, $translated_words): void
     {
@@ -101,8 +99,6 @@ class DomFormatter extends AbstractFormatter
     /**
      * @param string $translated
      * @param int    $index
-     *
-     * @return void
      */
     protected function imageSource(array $details, $translated, $index): void
     {

--- a/dependencies/weglot-php/src/Parser/Formatter/DomFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/DomFormatter.php
@@ -41,7 +41,7 @@ if (!\function_exists('array_column')) {
 
 class DomFormatter extends AbstractFormatter
 {
-    public function handle(array $nodes, &$index)
+    public function handle(array $nodes, &$index): void
     {
         $translatable_attributes = $this->getTranslatableAttributes();
 
@@ -69,7 +69,7 @@ class DomFormatter extends AbstractFormatter
      *
      * @return void
      */
-    protected function metaContent(array $details, $translated, $translatable_attributes, $original_words, $translated_words)
+    protected function metaContent(array $details, $translated, $translatable_attributes, $original_words, $translated_words): void
     {
         $property = $details['property'];
 
@@ -104,7 +104,7 @@ class DomFormatter extends AbstractFormatter
      *
      * @return void
      */
-    protected function imageSource(array $details, $translated, $index)
+    protected function imageSource(array $details, $translated, $index): void
     {
         $words = $this->getTranslated()->getInputWords();
 

--- a/dependencies/weglot-php/src/Parser/Formatter/DomFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/DomFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Formatter;
 
 if (!\function_exists('array_column')) {

--- a/dependencies/weglot-php/src/Parser/Formatter/ExcludeBlocksFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/ExcludeBlocksFormatter.php
@@ -121,7 +121,7 @@ class ExcludeBlocksFormatter
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         if (!empty($this->whiteList)) {
             foreach ($this->whiteList as $exception) {

--- a/dependencies/weglot-php/src/Parser/Formatter/ExcludeBlocksFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/ExcludeBlocksFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Formatter;
 
 use Weglot\Parser\Parser;

--- a/dependencies/weglot-php/src/Parser/Formatter/ExcludeBlocksFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/ExcludeBlocksFormatter.php
@@ -118,8 +118,6 @@ class ExcludeBlocksFormatter
      * Add ATTRIBUTE_NO_TRANSLATE to dom elements that don't
      * want to be translated or ATTRIBUTE_TRANSLATE if on mode
      * wg-mode-whitelist.
-     *
-     * @return void
      */
     public function handle(): void
     {

--- a/dependencies/weglot-php/src/Parser/Formatter/IgnoredNodes.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/IgnoredNodes.php
@@ -77,8 +77,6 @@ class IgnoredNodes
 
     /**
      * @param array $matches
-     *
-     * @return void
      */
     protected function replaceContent($matches): void
     {
@@ -94,8 +92,6 @@ class IgnoredNodes
     /**
      * Convert < & > for some dom tags to let them able
      * to go through API calls.
-     *
-     * @return void
      */
     public function handle(): void
     {

--- a/dependencies/weglot-php/src/Parser/Formatter/IgnoredNodes.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/IgnoredNodes.php
@@ -80,7 +80,7 @@ class IgnoredNodes
      *
      * @return void
      */
-    protected function replaceContent($matches)
+    protected function replaceContent($matches): void
     {
         $this->setSource(
             str_replace(
@@ -97,7 +97,7 @@ class IgnoredNodes
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         // time for the BIG regex ...
         $pattern = '#<(?<tag>'.implode('|', $this->ignoredNodes).')(?<more>\s.*?)?\>(?<content>[^>]*?)\<\/(?<tagclosed>'.implode('|', $this->ignoredNodes).')>#i';

--- a/dependencies/weglot-php/src/Parser/Formatter/IgnoredNodes.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/IgnoredNodes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Formatter;
 
 class IgnoredNodes

--- a/dependencies/weglot-php/src/Parser/Formatter/JsonFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/JsonFormatter.php
@@ -43,7 +43,7 @@ class JsonFormatter extends AbstractFormatter
         return $this->source;
     }
 
-    public function handle(array $tree, &$index)
+    public function handle(array $tree, &$index): void
     {
         $translated_words = $this->getTranslated()->getOutputWords();
 

--- a/dependencies/weglot-php/src/Parser/Formatter/JsonFormatter.php
+++ b/dependencies/weglot-php/src/Parser/Formatter/JsonFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser\Formatter;
 
 use Weglot\Client\Api\TranslateEntry;

--- a/dependencies/weglot-php/src/Parser/Parser.php
+++ b/dependencies/weglot-php/src/Parser/Parser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Parser;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Util/JsonUtil.php
+++ b/dependencies/weglot-php/src/Util/JsonUtil.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Util;
 
 use Weglot\Client\Api\Enum\WordType;

--- a/dependencies/weglot-php/src/Util/JsonUtil.php
+++ b/dependencies/weglot-php/src/Util/JsonUtil.php
@@ -28,8 +28,6 @@ class JsonUtil
     /**
      * @param string $value
      *
-     * @return void
-     *
      * @throws InvalidWordTypeException
      */
     public static function add(WordCollection $words, $value): void

--- a/dependencies/weglot-php/src/Util/JsonUtil.php
+++ b/dependencies/weglot-php/src/Util/JsonUtil.php
@@ -32,7 +32,7 @@ class JsonUtil
      *
      * @throws InvalidWordTypeException
      */
-    public static function add(WordCollection $words, $value)
+    public static function add(WordCollection $words, $value): void
     {
         $words->addOne(new WordEntry($value, WordType::TEXT));
     }

--- a/dependencies/weglot-php/src/Util/Regex.php
+++ b/dependencies/weglot-php/src/Util/Regex.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Util;
 
 use Weglot\Util\Regex\RegexEnum;

--- a/dependencies/weglot-php/src/Util/Regex/RegexEnum.php
+++ b/dependencies/weglot-php/src/Util/Regex/RegexEnum.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Util\Regex;
 
 abstract class RegexEnum

--- a/dependencies/weglot-php/src/Util/Server.php
+++ b/dependencies/weglot-php/src/Util/Server.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Util;
 
 use Weglot\Client\Api\Enum\BotType;

--- a/dependencies/weglot-php/src/Util/Site.php
+++ b/dependencies/weglot-php/src/Util/Site.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Util;
 
 class Site

--- a/dependencies/weglot-php/src/Util/SourceType.php
+++ b/dependencies/weglot-php/src/Util/SourceType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Util;
 
 /**

--- a/dependencies/weglot-php/src/Util/Text.php
+++ b/dependencies/weglot-php/src/Util/Text.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Util;
 
 class Text

--- a/dependencies/weglot-php/src/Util/Url.php
+++ b/dependencies/weglot-php/src/Util/Url.php
@@ -109,7 +109,7 @@ class Url
      *
      * @return void
      */
-    public function setUrl($url)
+    public function setUrl($url): void
     {
         $this->url = $url;
         $this->detectUrlDetails();

--- a/dependencies/weglot-php/src/Util/Url.php
+++ b/dependencies/weglot-php/src/Util/Url.php
@@ -106,8 +106,6 @@ class Url
      * Sets the full URL.
      *
      * @param string $url
-     *
-     * @return void
      */
     public function setUrl($url): void
     {

--- a/dependencies/weglot-php/src/Util/Url.php
+++ b/dependencies/weglot-php/src/Util/Url.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Weglot\Util;
 
 use Weglot\Client\Api\LanguageEntry;

--- a/rector.php
+++ b/rector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 

--- a/rector.php
+++ b/rector.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Isolated\Symfony\Component\Finder\Finder;
 
 return [

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 use Isolated\Symfony\Component\Finder\Finder;
 
 return [

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot;
 
 use craft\base\Model;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -275,6 +275,7 @@ class Plugin extends BasePlugin
                 Plugin::getInstance()->getOption()->generateWeglotData();
                 Plugin::getInstance()->getDynamics()->addDynamics();
                 $this->getFrontEndScripts()->injectSwitcherAssets();
+                $this->getFrontEndScripts()->injectAlgoliaScript();
                 $this->getPageViews()->injectPageViewsScript();
             }
         );

--- a/src/checkers/dom/ButtonDataValue.php
+++ b/src/checkers/dom/ButtonDataValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\checkers\dom;
 
 use Weglot\Vendor\Weglot\Client\Api\Enum\WordType;

--- a/src/checkers/dom/ButtonValue.php
+++ b/src/checkers/dom/ButtonValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\checkers\dom;
 
 use Weglot\Vendor\Weglot\Client\Api\Enum\WordType;

--- a/src/checkers/dom/InputReset.php
+++ b/src/checkers/dom/InputReset.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\checkers\dom;
 
 use Weglot\Vendor\Weglot\Client\Api\Enum\WordType;

--- a/src/checkers/dom/LinkDataHref.php
+++ b/src/checkers/dom/LinkDataHref.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\checkers\dom;
 
 use Weglot\Vendor\Weglot\Parser\Check\Dom\LinkHref;

--- a/src/checkers/dom/MetaFacebookImage.php
+++ b/src/checkers/dom/MetaFacebookImage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\checkers\dom;
 
 use Weglot\Vendor\Weglot\Client\Api\Enum\WordType;

--- a/src/checkers/dom/MetaTwitter.php
+++ b/src/checkers/dom/MetaTwitter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\checkers\dom;
 
 use Weglot\Vendor\Weglot\Client\Api\Enum\WordType;

--- a/src/checkers/dom/MetaTwitterImage.php
+++ b/src/checkers/dom/MetaTwitterImage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\checkers\dom;
 
 use Weglot\Vendor\Weglot\Client\Api\Enum\WordType;

--- a/src/checkers/dom/VideoSource.php
+++ b/src/checkers/dom/VideoSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\checkers\dom;
 
 use Weglot\Vendor\Weglot\Client\Api\Enum\WordType;

--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\controllers;
 
 use craft\web\Controller;

--- a/src/controllers/RouterController.php
+++ b/src/controllers/RouterController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\controllers;
 
 use craft\base\Element;

--- a/src/events/RegisterSelectorsEvent.php
+++ b/src/events/RegisterSelectorsEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\events;
 
 use yii\base\Event;

--- a/src/helpers/DashboardHelper.php
+++ b/src/helpers/DashboardHelper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\helpers;
 
 use craft\helpers\App;

--- a/src/helpers/HelperApi.php
+++ b/src/helpers/HelperApi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\helpers;
 
 use craft\helpers\App;

--- a/src/helpers/HelperFlagType.php
+++ b/src/helpers/HelperFlagType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\helpers;
 
 class HelperFlagType

--- a/src/helpers/HelperReplaceUrl.php
+++ b/src/helpers/HelperReplaceUrl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\helpers;
 
 class HelperReplaceUrl

--- a/src/helpers/HelperSwitcher.php
+++ b/src/helpers/HelperSwitcher.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\helpers;
 
 class HelperSwitcher

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\models;
 
 use craft\base\Model;

--- a/src/resources/AdminAsset.php
+++ b/src/resources/AdminAsset.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\resources;
 
 use craft\web\AssetBundle;

--- a/src/services/DomCheckersService.php
+++ b/src/services/DomCheckersService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/DynamicsService.php
+++ b/src/services/DynamicsService.php
@@ -56,9 +56,6 @@ final class DynamicsService
             'whitelist' => $whitelist,
             'dynamics' => $dynamics,
         ]);
-
-        // Inject Algolia script if enabled
-        Plugin::getInstance()->getFrontEndScripts()->injectAlgoliaScript();
     }
 
     /**

--- a/src/services/DynamicsService.php
+++ b/src/services/DynamicsService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use weglot\craftweglot\events\RegisterSelectorsEvent;

--- a/src/services/FrontEndScriptsService.php
+++ b/src/services/FrontEndScriptsService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/HrefLangService.php
+++ b/src/services/HrefLangService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/LanguageService.php
+++ b/src/services/LanguageService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/OptionService.php
+++ b/src/services/OptionService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/PageViewsService.php
+++ b/src/services/PageViewsService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/ParserService.php
+++ b/src/services/ParserService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/RedirectService.php
+++ b/src/services/RedirectService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/RegexCheckersService.php
+++ b/src/services/RegexCheckersService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/ReplaceLinkService.php
+++ b/src/services/ReplaceLinkService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/ReplaceUrlService.php
+++ b/src/services/ReplaceUrlService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/RequestUrlService.php
+++ b/src/services/RequestUrlService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/SlugService.php
+++ b/src/services/SlugService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/TranslateService.php
+++ b/src/services/TranslateService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/services/UserApiService.php
+++ b/src/services/UserApiService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\services;
 
 use craft\base\Component;

--- a/src/web/WeglotVirtualRequest.php
+++ b/src/web/WeglotVirtualRequest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace weglot\craftweglot\web;
 
 use craft\web\Request;

--- a/src/web/WeglotVirtualRequest.php
+++ b/src/web/WeglotVirtualRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\web;
 
 use craft\web\Request;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 use craft\i18n\PhpMessageSource;
 use weglot\craftweglot\Plugin;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use craft\i18n\PhpMessageSource;
 use weglot\craftweglot\Plugin;
 

--- a/tests/services/ReplaceUrlServiceTest.php
+++ b/tests/services/ReplaceUrlServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\tests\services;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/PluginTest.php
+++ b/tests/unit/PluginTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\tests\unit;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/PluginTest.php
+++ b/tests/unit/PluginTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace weglot\craftweglot\tests\unit;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/helpers/HelperReplaceUrlTest.php
+++ b/tests/unit/helpers/HelperReplaceUrlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\tests\unit\helpers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/helpers/HelperReplaceUrlTest.php
+++ b/tests/unit/helpers/HelperReplaceUrlTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace weglot\craftweglot\tests\unit\helpers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/services/LanguageServiceLegacyFallbackTest.php
+++ b/tests/unit/services/LanguageServiceLegacyFallbackTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace weglot\craftweglot\tests\unit\services;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/services/LanguageServiceLegacyFallbackTest.php
+++ b/tests/unit/services/LanguageServiceLegacyFallbackTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\tests\unit\services;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/services/LanguageServiceTest.php
+++ b/tests/unit/services/LanguageServiceTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace weglot\craftweglot\tests\unit\services;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/services/LanguageServiceTest.php
+++ b/tests/unit/services/LanguageServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\tests\unit\services;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/services/ReplaceLinkServiceReplaceATest.php
+++ b/tests/unit/services/ReplaceLinkServiceReplaceATest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace weglot\craftweglot\tests\unit\services;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/services/ReplaceLinkServiceReplaceATest.php
+++ b/tests/unit/services/ReplaceLinkServiceReplaceATest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\tests\unit\services;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/services/ReplaceLinkServiceTest.php
+++ b/tests/unit/services/ReplaceLinkServiceTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace weglot\craftweglot\tests\unit\services;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/services/ReplaceLinkServiceTest.php
+++ b/tests/unit/services/ReplaceLinkServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace weglot\craftweglot\tests\unit\services;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad dependency upgrades plus enabling strict types and adding return types can surface runtime type errors and subtle behavior changes, especially in bundled vendor code and frontend script injection timing.
> 
> **Overview**
> Enables `strict_types` across the codebase (and configures php-cs-fixer to enforce it), adding numerous `: void` return types throughout bundled dependencies and plugin code.
> 
> Adjusts frontend injection flow so Algolia’s script injection is triggered from the global `EVENT_BEGIN_PAGE` hook (not via `DynamicsService`), while dynamics selectors are now sourced from the `dynamics` option and merged into the Weglot `whitelist/dynamics` initialization payload.
> 
> Updates `composer.lock` with a Craft CMS patch bump plus multiple dependency upgrades, including switching GraphQL from `webonyx/graphql-php` to `pixelandtonic/graphql-php` and updating tooling dependencies like `friendsofphp/php-cs-fixer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c9b5f719551a1d52ea26ae5dbea5c32012edfef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->