### PR TITLE
Update create-release.yml

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,26 +5,22 @@ name: Create Release
 run-name: Create release for ${{ github.event.client_payload.version }}
 
 on:
-    repository_dispatch:
-        types:
-            - craftcms/new-release
-    pull_request:
-    push:
-      branches:
-        - master
+  push:
+    tags:
+      - '*'
 
 jobs:
-    release:
-      if: github.event.client_payload.tag != null
-      runs-on: ubuntu-latest
-      permissions:
-        contents: write
-      steps:
-        - name: Create release
-          uses: ncipollo/release-action@v1
-          with:
-            body: ${{ github.event.client_payload.notes }}
-            makeLatest: ${{ github.event.client_payload.latest }}
-            name: ${{ github.event.client_payload.version }}
-            prerelease: ${{ github.event.client_payload.prerelease }}
-            tag: ${{ github.event.client_payload.tag }}
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: Automated release for ${{ github.ref_name }}
+          prerelease: false
+          makeLatest: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that alters when releases are created; main risk is unintended releases for any pushed tag due to the broad `'*'` tag pattern.
> 
> **Overview**
> Switches the `Create Release` GitHub Actions workflow from a `repository_dispatch`-driven flow (using Craft Plugin Store payload fields) to running on any `push` of a tag.
> 
> Updates the release step to use `github.ref_name` for the release `tag`/`name` and replaces payload-based notes/prerelease/latest settings with a fixed automated body and `makeLatest: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c1b347d68ae66d296543839aceeafee6ac6804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->