### PR TITLE
fix(replace-url): leave non-navigational schemes untouched

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,16 @@ make all          # Full update: checkout + scoper + vendor-sync
 make clean        # Remove all build artifacts
 ```
 
+### After any vendor update — regenerate the autoloader
+
+The scoped `weglot-php` parser discovers its DOM checkers by scanning the `Parser/Check/Dom/` directory at runtime (`DomCheckerProvider::loadDefaultCheckers()` uses `scandir()`), then builds each class name from the filename. Those classes are autoloaded via the **classmap** declared in `composer.json` (`autoload.classmap`), which is a static generated list.
+
+So whenever `make vendor-sync` / `make all` **adds or removes** a checker file (or any scoped class), you MUST run `composer dump-autoload` in every project that consumes the plugin. Otherwise `scandir()` finds a file the classmap doesn't know about and the parser throws `Class "\Weglot\Vendor\Weglot\Parser\Check\Dom\..." not found` at runtime (this is exactly how a newly-added `ImageSourceSet` checker broke translation until the autoloader was regenerated).
+
+```bash
+composer dump-autoload   # run in the Craft project root after every vendor update
+```
+
 ---
 
 ## Manual Release (GitHub)

--- a/src/services/ReplaceLinkService.php
+++ b/src/services/ReplaceLinkService.php
@@ -29,6 +29,14 @@ class ReplaceLinkService extends Component
      */
     public function replaceUrl(string $url, LanguageEntry $language, bool $evenExcluded = true): string
     {
+        // Non-navigational schemes (mailto:, tel:, sms:, javascript:, data:, ...) must never be
+        // rewritten: parse_url() returns no host for them, so the external-host guard below would
+        // not catch them and the URL would wrongly get a language prefix.
+        $scheme = parse_url($url, \PHP_URL_SCHEME);
+        if (\is_string($scheme) && !\in_array(strtolower($scheme), ['http', 'https'], true)) {
+            return $url;
+        }
+
         $currentHost = parse_url($this->requestUrlService->getFullUrl(), \PHP_URL_HOST);
         $urlHost = parse_url($url, \PHP_URL_HOST);
 

--- a/tests/unit/services/ReplaceLinkServiceTest.php
+++ b/tests/unit/services/ReplaceLinkServiceTest.php
@@ -129,6 +129,35 @@ final class ReplaceLinkServiceTest extends TestCase
         self::assertSame($url, $svc->replaceUrl($url, $this->fr));
     }
 
+    /**
+     * Non-navigational schemes carry no host, so the external-host guard cannot catch them; they
+     * must still be left untouched instead of being treated as internal paths and getting a wrong
+     * language prefix (e.g. mailto:a@b.com -> /fr/a@b.com/).
+     *
+     * @dataProvider nonNavigationalUrlProvider
+     */
+    public function testReplaceUrlLeavesNonNavigationalSchemesUntouched(string $url): void
+    {
+        $rus = $this->makeRusNoTranslation('https://example.com/page');
+        $svc = new ReplaceLinkService($rus);
+
+        self::assertSame($url, $svc->replaceUrl($url, $this->fr));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function nonNavigationalUrlProvider(): array
+    {
+        return [
+            'mailto' => ['mailto:concierge@weglot-craft-project.ddev.site'],
+            'tel' => ['tel:+33123456789'],
+            'sms' => ['sms:+33123456789'],
+            'javascript' => ['javascript:void(0)'],
+            'data' => ['data:text/plain;base64,SGVsbG8='],
+        ];
+    }
+
     // -------------------------------------------------------------------------
     // replaceA — regex substitution
     // -------------------------------------------------------------------------


### PR DESCRIPTION
mailto:, tel:, sms: and similar links carry no host, so the external-host guard in ReplaceLinkService::replaceUrl() did not catch them: they were treated as internal paths and wrongly received a language prefix (mailto:a@b.com -> /it/a@b.com/). Skip any URL whose scheme is not http/https.

Also document that composer dump-autoload must be run after every vendor update, since the scoped parser discovers DOM checkers via scandir() but loads them through the composer classmap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted guard in URL rewriting with unit tests; documentation-only vendor workflow note. No auth or data-path changes.
> 
> **Overview**
> **`ReplaceLinkService::replaceUrl()`** now returns the original URL unchanged when the scheme is anything other than `http` or `https`. That closes a gap where `mailto:`, `tel:`, `sms:`, `javascript:`, and `data:` links (no host for the external-host check) were rewritten with a language prefix.
> 
> Unit coverage was added via a data provider for those scheme types.
> 
> **`CLAUDE.md`** documents that **`composer dump-autoload`** must be run in consuming Craft projects after vendor sync when scoped DOM checker files are added or removed, because runtime `scandir()` discovery must stay in sync with Composer’s classmap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 074e2e65acedd1c1ecab985558135c192f06f612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->