### PR TITLE
docs(changelog): add 1.2.7 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Weglot
 
+## 1.2.7 - 2026-07-13
+
+- Fix: URLs using non-navigational schemes (mailto:, tel:, sms:, javascript:, data:, ...) are no longer rewritten with a language prefix; only http/https links go through language rewriting and slug translation.
+
 ## 1.2.6 - 2026-06-23
 
 - Improvement: Adds htmx attribute URL rewriting support, extending the existing URL replacement pipeline to translate URLs found in `hx-*` attributes.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changelog-only change with no runtime or configuration impact.
> 
> **Overview**
> Adds a **1.2.7 (2026-07-13)** section at the top of `CHANGELOG.md`, documenting a fix where links with non-navigational schemes (`mailto:`, `tel:`, `sms:`, `javascript:`, `data:`, etc.) are excluded from Weglot language-prefix and slug rewriting, so only `http`/`https` URLs are processed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69601330e7797ef2d5f6cab990f84100953714d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->