### PR TITLE
fix(replace-url): leave same-document references untouched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Weglot
 
+## 1.2.8 - 2026-07-29
+
+- Fix: Same-document links (fragment-only `#anchor` / `#/spa/route` and query-only `?foo=bar` hrefs) are no longer rewritten with a language prefix on translated pages; they now stay relative to the current page instead of being rebased onto the language root (e.g. `#/booking/step-1?` no longer becomes `/fr/#/booking/step-1?`), fixing in-page and SPA navigation.
+
 ## 1.2.7 - 2026-07-13
 
 - Fix: URLs using non-navigational schemes (mailto:, tel:, sms:, javascript:, data:, ...) are no longer rewritten with a language prefix; only http/https links go through language rewriting and slug translation.

--- a/src/services/ReplaceLinkService.php
+++ b/src/services/ReplaceLinkService.php
@@ -29,6 +29,15 @@ class ReplaceLinkService extends Component
      */
     public function replaceUrl(string $url, LanguageEntry $language, bool $evenExcluded = true): string
     {
+        // Same-document references ("#anchor", "#/spa/route", "?foo=bar") resolve against the
+        // current page. parse_url() reports no host and no path for them, so the guards below
+        // would not catch them and they would wrongly receive a language prefix (e.g.
+        // "#/booking" -> "/fr/#/booking"), rebasing the link onto /fr/ and breaking in-page and
+        // SPA navigation. Leave them untouched.
+        if ('' === $url || '#' === $url[0] || '?' === $url[0]) {
+            return $url;
+        }
+
         // Non-navigational schemes (mailto:, tel:, sms:, javascript:, data:, ...) must never be
         // rewritten: parse_url() returns no host for them, so the external-host guard below would
         // not catch them and the URL would wrongly get a language prefix.

--- a/tests/unit/services/ReplaceLinkServiceTest.php
+++ b/tests/unit/services/ReplaceLinkServiceTest.php
@@ -69,6 +69,33 @@ final class ReplaceLinkServiceTest extends TestCase
     }
 
     /**
+     * Build a RequestUrlService stub whose createUrlObject() throws. The
+     * same-document guard in replaceUrl() must short-circuit before any URL
+     * object is built, so createUrlObject() should never be reached; if the
+     * guard failed, replaceUrl() would call it and the exception would fail the
+     * test.
+     */
+    private function makeRusRejectingUrlBuild(string $currentUrl): RequestUrlService
+    {
+        return new class($currentUrl) extends RequestUrlService {
+            public function __construct(private readonly string $currentUrl)
+            {
+                parent::__construct();
+            }
+
+            public function getFullUrl(bool $useForwardedHost = false): string
+            {
+                return $this->currentUrl;
+            }
+
+            public function createUrlObject(string $url): Url
+            {
+                throw new \LogicException('createUrlObject() must not be reached for same-document references');
+            }
+        };
+    }
+
+    /**
      * Build a ReplaceLinkService subclass whose replaceUrl() returns a
      * controlled translated URL, bypassing all API and service calls.
      * Also injects a matching RequestUrlService stub into the plugin so that
@@ -155,6 +182,37 @@ final class ReplaceLinkServiceTest extends TestCase
             'sms' => ['sms:+33123456789'],
             'javascript' => ['javascript:void(0)'],
             'data' => ['data:text/plain;base64,SGVsbG8='],
+        ];
+    }
+
+    /**
+     * Fragment-only and query-only hrefs are references to the current document; they must be
+     * returned untouched instead of receiving a language prefix, which would rebase them onto
+     * /fr/ and break in-page / SPA navigation (e.g. "#/booking/step-1?" -> "/fr/#/booking/step-1?").
+     * The stub throws if replaceUrl() tries to build a URL object, so the test fails if the
+     * guard does not short-circuit.
+     *
+     * @dataProvider sameDocumentUrlProvider
+     */
+    public function testReplaceUrlLeavesSameDocumentReferencesUntouched(string $url): void
+    {
+        $rus = $this->makeRusRejectingUrlBuild('https://example.com/event');
+        $svc = new ReplaceLinkService($rus);
+
+        self::assertSame($url, $svc->replaceUrl($url, $this->fr));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function sameDocumentUrlProvider(): array
+    {
+        return [
+            'spa fragment route' => ['#/booking/step-1?'],
+            'simple anchor' => ['#section'],
+            'bare hash' => ['#'],
+            'query only' => ['?foo=bar'],
+            'bare question mark' => ['?'],
         ];
     }
 


### PR DESCRIPTION
## Problem

On translated pages, `ReplaceLinkService::replaceUrl()` treated **fragment-only** (`#anchor`, `#/spa/route`) and **query-only** (`?foo=bar`) hrefs as path-less internal URLs and prepended the language prefix.

Concrete case (missclarahotel.com):
- Original page `…/event`, DOM `href="#/booking/step-1?"` → browser resolves to `…/event#/booking/step-1?` ✅
- Translated page `…/fr/event`, DOM was rewritten to `href="/fr/#/booking/step-1?"` → resolves to `…/fr/#/booking/step-1?` ❌ (the `/event` base is lost, breaking in-page / SPA navigation)

A same-document reference (`#…` / `?…`) resolves against the current page and must never receive a language prefix.

## Fix

Add an early guard at the top of `replaceUrl()` (same spirit as #60, which left non-navigational schemes untouched): if the URL is empty or starts with `#` or `?`, return it unchanged before any URL object is built.

## Tests

New data-driven coverage in `ReplaceLinkServiceTest` for `#/booking/step-1?`, `#section`, `#`, `?foo=bar`, `?`. The stub throws if `replaceUrl()` tries to build a URL object, so the test fails if the guard does not short-circuit.

## QA

- `composer run check-cs` — clean
- `composer run phpstan` — no new errors vs. baseline
- `composer run rector` — no pending transforms
- `composer run test` — 146/146 green

CHANGELOG entry added under 1.2.8.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard in link replacement with regression tests; no auth, data, or API contract changes.
> 
> **Overview**
> **Fixes translated-page link rewriting for fragment and query-only hrefs** so in-page and SPA navigation stay on the current URL instead of rebasing onto the language root.
> 
> `ReplaceLinkService::replaceUrl()` now returns early when the href is empty or starts with `#` or `?`, matching the existing pattern for non-navigational schemes. Without this guard, values like `#/booking/step-1?` were prefixed (e.g. `/fr/#/booking/step-1?`), dropping the page path segment.
> 
> Unit tests cover SPA fragments, anchors, bare `#`/`?`, and query-only hrefs, with a stub that fails if the guard does not short-circuit before URL object creation. CHANGELOG documents the fix under **1.2.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72cf88fad50dcb3c777aac37da2e0e61ef80b3e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->