### PR TITLE
docs(changelog): add 1.2.8 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 1.2.8 - 2026-07-29
 
 - Fix: Same-document links (fragment-only `#anchor` / `#/spa/route` and query-only `?foo=bar` hrefs) are no longer rewritten with a language prefix on translated pages; they now stay relative to the current page instead of being rebased onto the language root (e.g. `#/booking/step-1?` no longer becomes `/fr/#/booking/step-1?`), fixing in-page and SPA navigation.
+- Fix: Restores translation of the `srcset` attribute on `<img>` in translated pages. The responsible checker was dropped in the library split, so a translated `src` could previously coexist with original-language `srcset` URLs.
+- Fix: The `media_enabled` and `external_enabled` options now correctly disable translation of media attributes (`src`, `data-src`, `srcset`) and external links respectively; a class-name matching bug previously made both toggles silent no-ops.
+- Improvement: Migrates the bundled Weglot PHP library to weglot-php 1.9.9, whose parsing layer is now extracted into a separate weglot-parser-php 0.1.1 dependency; the scoped vendor and the DOM/regex checker wiring were updated accordingly, with no change to translation output.
+- Improvement: Updates locked dependencies to clear all reported security advisories — guzzlehttp/guzzle 7.15.2, guzzlehttp/psr7 2.13.0, and craftcms/cms 5.10.12 (pulling fixed phpoffice/phpspreadsheet and web-auth/webauthn-lib) — all within the existing version constraints.
 
 ## 1.2.7 - 2026-07-13
 


### PR DESCRIPTION
Adds the `1.2.8` release notes (next version after the current `1.2.7` tag), consolidating all changes merged since 1.2.7 into a single entry dated 2026-07-29:

- **Fix** — same-document links (`#…` / `?…` hrefs) no longer rewritten with a language prefix on translated pages.
- **Fix** — `<img srcset>` translation restored (checker was dropped in the library split).
- **Fix** — `media_enabled` / `external_enabled` toggles now actually disable media (`src`/`data-src`/`srcset`) and external-link translation (previously silent no-ops).
- **Improvement** — migration to weglot-php 1.9.9 with the parsing layer extracted into weglot-parser-php 0.1.1.
- **Improvement** — locked dependencies updated to clear all security advisories (guzzle 7.15.2, psr7 2.13.0, craftcms/cms 5.10.12), within existing constraints.

Docs-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md with no code or dependency updates in this diff.
> 
> **Overview**
> Adds a **1.2.8** section dated 2026-07-29 to `CHANGELOG.md`, documenting fixes and improvements already merged since 1.2.7.
> 
> The new bullets cover same-document link rewriting on translated pages, restored `<img srcset>` translation, working `media_enabled` / `external_enabled` toggles, the weglot-php 1.9.9 / weglot-parser-php 0.1.1 migration, and dependency bumps to clear security advisories.
> 
> This PR only updates release notes; it does not change plugin runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85c87d8b4c3df672aa944febdc299b3c23886686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->